### PR TITLE
Rename affiliation variable and commenting packages

### DIFF
--- a/affiliations.tex
+++ b/affiliations.tex
@@ -14,7 +14,7 @@
 \newcommand{\ESO}{\affil{European Southern Observatory, Karl-Schwarzschild Stra{\ss}e 2, D-85748 Garching bei M\"{u}nchen, Germany}}
 
 % Green Bank
-\newcommand{\GBT}{\affil{Green Bank Observatory, 155 Observatory Rd., Green Bank, WV 24944, USA}}
+\newcommand{\GBO}{\affil{Green Bank Observatory, 155 Observatory Rd., Green Bank, WV 24944, USA}}
 
 % Heidelberg University ARI
 \newcommand{\Heidelberg}{\affil{Astronomisches Rechen-Institut, Zentrum f\"{u}r Astronomie der Universit\"{a}t Heidelberg, M\"{o}nchhofstra\ss e 12-14, D-69120 Heidelberg, Germany}}

--- a/packages.tex
+++ b/packages.tex
@@ -1,10 +1,15 @@
 % import packages here
 
+% amsmath with fleqn causes "LaTeX Error: Option clash for package amsmath."	
+% float is already loaded via amsmath
+% loading amssymb causes "LaTeX Error: Command `\Bbbk' already defined." error with the MNRAS package
+
+
 \usepackage{graphicx}	% Including figure files
-\usepackage[fleqn]{amsmath}	% Advanced maths commands
-\usepackage{float}
+%\usepackage[fleqn]{amsmath}	% Advanced maths commands
+%\usepackage{float}
 \usepackage{amstext}
-\usepackage{amssymb}	% Extra maths symbols
+%\usepackage{amssymb}	% Extra maths symbols
 \usepackage{url}
 \usepackage{tabularx}
 \usepackage{mathtools}


### PR DESCRIPTION
(1) Renamed GBT as GBO
(2) Commented out 3 packages in packages.tex that cause compilation errors with the MNRAS 
    - amsmath with fleqn causes "LaTeX Error: Option clash for package amsmath."	
    - float is already loaded via amsmath
    - loading amssymb causes "LaTeX Error: Command `\Bbbk' already defined." error with the MNRAS package